### PR TITLE
Fix script generator, to work with lxc version over 3.x.

### DIFF
--- a/network_sim/linux_containers/templates/lxc.conf.template
+++ b/network_sim/linux_containers/templates/lxc.conf.template
@@ -1,9 +1,9 @@
 # Container with network virtualized using a pre-configured bridge named BRIDGE_NAME and
 # veth pair virtual network devices
-lxc.utsname = CONTAINER_NAME
+# lxc.host.name = CONTAINER_NAME
 
 NET_CONF
-lxc.mount.entry = /home/hokeunkim/Development home/hokeunkim/Development none bind,create=dir 0.0 
-lxc.mount.entry = /usr/bin usr/bin none bind,create=dir 0.0 
-lxc.mount.entry = /usr/lib usr/lib none bind,create=dir 0.0 
-lxc.mount.entry = /etc/alternatives etc/alternatives none bind,create=dir 0.0 
+lxc.mount.entry = ../../ ../../ none bind,create=dir 0 0 
+lxc.mount.entry = /usr/bin usr/bin none bind,create=dir 0 0 
+lxc.mount.entry = /usr/lib usr/lib none bind,create=dir 0 0 
+lxc.mount.entry = /etc/alternatives etc/alternatives none bind,create=dir 0 0 

--- a/network_sim/linux_containers/templates/lxc.conf.template
+++ b/network_sim/linux_containers/templates/lxc.conf.template
@@ -3,7 +3,7 @@
 # lxc.host.name = CONTAINER_NAME
 
 NET_CONF
-lxc.mount.entry = ../../ ../../ none bind,create=dir 0 0 
+lxc.mount.entry = PWD PWD none bind,create=dir 0 0 
 lxc.mount.entry = /usr/bin usr/bin none bind,create=dir 0 0 
 lxc.mount.entry = /usr/lib usr/lib none bind,create=dir 0 0 
 lxc.mount.entry = /etc/alternatives etc/alternatives none bind,create=dir 0 0 

--- a/network_sim/linux_containers/templates/setup-virtual-network.sh.template
+++ b/network_sim/linux_containers/templates/setup-virtual-network.sh.template
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Cleanup existing resources (bridges and TAP devices)
+CLEANUP_COMMANDS
+
 # run this after using 'chroot /'
 
 # add bridges
@@ -16,9 +19,7 @@ brctl show
 
 # create containers using lxc-create (lxc: linux container)
 # if you use -t none, it may crash (use -t for template, -d for distribution, -r for release, -a for architecture)
-# do this in $NS3/src/tap-bridge/examples
 CREATE_CONTAINER_COMMANDS
 
 # see if containers are created correctly
 lxc-ls
-


### PR DESCRIPTION
Also add cleanup commands.

Also, replace `ifconfig` to `ip`.

```
function addTapBridgeCommands(commands, bridgeName, tapName) {
    // for setup script
    commands.addBridge += 'brctl addbr ' + bridgeName + '\n';
    commands.createTap += 'tunctl -t ' + tapName + '\n';
    commands.setTapPersistent += 'ip link set ' + tapName + ' up\nip link set ' + tapName + ' promisc on\n';
    commands.addBridgeToTap += 'brctl addif ' + bridgeName + ' ' + tapName + '\nip link set ' + bridgeName + ' up\n';
    // for teardown script
    commands.bridgeDown += 'ip link set ' + bridgeName + ' down\n';
    commands.removeBridgeFromTap += 'brctl delif ' + bridgeName + ' ' + tapName + '\n';
    commands.deleteBridge += 'brctl delbr ' + bridgeName + '\n';
    commands.tapDown += 'ip link set ' + tapName + ' down\n';
    commands.setTapNonPersistent += 'tunctl -d ' + tapName + '\n';
    return commands;
}
```