### PR TITLE
Added initialization process and some elements to the graph.

### DIFF
--- a/expConfigs/cory345.graph
+++ b/expConfigs/cory345.graph
@@ -347,6 +347,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s301.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -370,6 +378,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s302.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -393,6 +409,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s303.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -416,6 +440,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s304.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -439,6 +471,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s305.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -462,6 +502,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s306.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				302,
 				402,
@@ -485,6 +533,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s307.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -508,6 +564,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s308.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -531,6 +595,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s309.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -554,6 +626,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s310.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				402,
@@ -577,6 +657,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s311.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				403,
@@ -600,6 +688,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s312.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -623,6 +719,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s313.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -646,6 +750,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s314.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -669,6 +781,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s315.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -692,6 +812,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s316.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -715,6 +843,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s317.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				401,
@@ -738,6 +874,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s318.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				403,
@@ -761,6 +905,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s319.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -784,6 +936,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				301,
@@ -807,6 +967,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				304,
 				501,
@@ -830,6 +998,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				301,
@@ -853,6 +1029,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				301,
@@ -876,6 +1060,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				301,
@@ -899,6 +1091,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -922,6 +1122,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -945,6 +1153,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -968,6 +1184,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -991,6 +1215,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -1014,6 +1246,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				304,
 				504,
@@ -1037,6 +1277,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				304,
@@ -1060,6 +1308,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				304,
@@ -1083,6 +1339,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				304,
@@ -1106,6 +1370,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				304,
@@ -1129,6 +1401,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				503,
@@ -1152,6 +1432,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -1175,6 +1463,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -1198,6 +1494,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1221,6 +1525,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -1244,6 +1556,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -1267,6 +1587,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1290,6 +1618,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1313,6 +1649,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1336,6 +1680,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -1359,6 +1711,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -1382,6 +1742,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -1405,6 +1773,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -1428,6 +1804,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -1451,6 +1835,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				403,
@@ -1474,6 +1866,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				403,
@@ -1497,6 +1897,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				303,
@@ -1520,6 +1928,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				304,
@@ -1543,6 +1959,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -1566,6 +1990,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -1587,6 +2019,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c301.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1615,6 +2055,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c302.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1643,6 +2091,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c303.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1671,6 +2127,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c304.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1699,6 +2163,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c305.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1727,6 +2199,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c306.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1755,6 +2235,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c307.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				302,
 				402,
@@ -1783,6 +2271,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c308.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				402,
@@ -1811,6 +2307,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c309.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1839,6 +2343,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c310.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1867,6 +2379,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c311.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1895,6 +2415,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c312.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				402,
@@ -1923,6 +2451,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c313.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				403,
@@ -1951,6 +2487,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c314.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				403,
@@ -1979,6 +2523,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c315.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				402,
@@ -2007,6 +2559,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c316.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -2035,6 +2595,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c317.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -2063,6 +2631,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c318.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -2091,6 +2667,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c319.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -2119,6 +2703,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c320.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -2147,6 +2739,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c321.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				401,
@@ -2175,6 +2775,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c322.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				403,
@@ -2203,6 +2811,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c323.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				403,
@@ -2231,6 +2847,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c324.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -2259,6 +2883,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				301,
@@ -2287,6 +2919,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				304,
 				501,
@@ -2315,6 +2955,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				304,
 				504,
@@ -2343,6 +2991,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				301,
@@ -2371,6 +3027,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				301,
@@ -2399,6 +3063,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				301,
@@ -2427,6 +3099,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				301,
@@ -2455,6 +3135,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -2483,6 +3171,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -2511,6 +3207,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -2539,6 +3243,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -2567,6 +3279,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				302,
@@ -2595,6 +3315,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				302,
 				502,
@@ -2623,6 +3351,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				304,
@@ -2651,6 +3387,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				304,
 				504,
@@ -2679,6 +3423,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				304,
@@ -2707,6 +3459,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				304,
@@ -2735,6 +3495,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				503,
@@ -2763,6 +3531,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				503,
@@ -2791,6 +3567,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -2819,6 +3603,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -2847,6 +3639,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -2875,6 +3675,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -2903,6 +3711,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -2931,6 +3747,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -2959,6 +3783,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -2987,6 +3819,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				301,
@@ -3015,6 +3855,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -3043,6 +3891,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -3071,6 +3927,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -3099,6 +3963,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -3127,6 +3999,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -3155,6 +4035,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -3183,6 +4071,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -3211,6 +4107,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -3239,6 +4143,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -3267,6 +4179,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				302,
@@ -3295,6 +4215,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				403,
@@ -3323,6 +4251,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				303,
 				403,
@@ -3351,6 +4287,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				303,
@@ -3379,6 +4323,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				304,
@@ -3407,6 +4359,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				304,
 				503,
@@ -3435,6 +4395,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -3463,6 +4431,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -3491,6 +4467,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,

--- a/expConfigs/cory345.graph
+++ b/expConfigs/cory345.graph
@@ -4494,5 +4494,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45.graph
+++ b/expConfigs/cory45.graph
@@ -2762,5 +2762,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45.graph
+++ b/expConfigs/cory45.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -249,6 +257,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				504,
@@ -270,6 +286,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -291,6 +315,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -312,6 +344,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -333,6 +373,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -354,6 +402,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -375,6 +431,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -396,6 +460,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -417,6 +489,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -438,6 +518,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				401,
@@ -459,6 +547,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -480,6 +576,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -501,6 +605,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -522,6 +634,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -543,6 +663,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -564,6 +692,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -585,6 +721,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -606,6 +750,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -627,6 +779,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -648,6 +808,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -669,6 +837,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -690,6 +866,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -711,6 +895,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -732,6 +924,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -753,6 +953,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -774,6 +982,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -795,6 +1011,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -816,6 +1040,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				403,
@@ -837,6 +1069,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -858,6 +1098,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -879,6 +1127,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -900,6 +1156,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -921,6 +1185,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -942,6 +1214,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -961,6 +1241,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -987,6 +1275,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				504,
@@ -1013,6 +1309,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				403,
@@ -1039,6 +1343,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -1065,6 +1377,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -1091,6 +1411,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -1117,6 +1445,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1143,6 +1479,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1169,6 +1513,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1195,6 +1547,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1221,6 +1581,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1247,6 +1615,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1273,6 +1649,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1299,6 +1683,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -1325,6 +1717,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -1351,6 +1751,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -1377,6 +1785,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -1403,6 +1819,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402,
@@ -1429,6 +1853,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -1455,6 +1887,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1481,6 +1921,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1507,6 +1955,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1533,6 +1989,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1559,6 +2023,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1585,6 +2057,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1611,6 +2091,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1637,6 +2125,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1663,6 +2159,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1689,6 +2193,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1715,6 +2227,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1741,6 +2261,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1767,6 +2295,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1793,6 +2329,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1819,6 +2363,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1845,6 +2397,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1871,6 +2431,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1897,6 +2465,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1923,6 +2499,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -1949,6 +2533,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -1975,6 +2567,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -2001,6 +2601,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -2027,6 +2635,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -2053,6 +2669,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -2079,6 +2703,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -2105,6 +2737,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,

--- a/expConfigs/cory45_ILP.graph
+++ b/expConfigs/cory45_ILP.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -244,6 +252,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -260,6 +276,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -276,6 +300,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -292,6 +324,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				401,
@@ -310,6 +350,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				401,
@@ -328,6 +376,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -346,6 +402,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -364,6 +428,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -382,6 +454,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				401,
@@ -400,6 +480,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -418,6 +506,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -435,6 +531,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -453,6 +557,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -469,6 +581,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -485,6 +605,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -501,6 +629,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -518,6 +654,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -535,6 +679,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -553,6 +705,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -570,6 +730,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -587,6 +755,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -604,6 +780,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				401,
@@ -622,6 +806,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -637,6 +829,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -652,6 +852,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -667,6 +875,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -682,6 +898,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -697,6 +921,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -712,6 +944,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -728,6 +968,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -745,6 +993,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -762,6 +1018,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -779,6 +1043,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503,
@@ -797,6 +1069,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -813,6 +1093,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -834,6 +1122,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -855,6 +1151,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -876,6 +1180,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -897,6 +1209,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -918,6 +1238,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401
@@ -939,6 +1267,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -963,6 +1299,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -986,6 +1330,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1008,6 +1360,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1030,6 +1390,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				401,
@@ -1053,6 +1421,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1075,6 +1451,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1098,6 +1482,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1120,6 +1512,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1142,6 +1542,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -1165,6 +1573,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1187,6 +1603,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1209,6 +1633,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1231,6 +1663,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1253,6 +1693,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1275,6 +1723,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1298,6 +1754,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1321,6 +1785,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -1344,6 +1816,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1366,6 +1846,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1387,6 +1875,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1410,6 +1906,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1432,6 +1936,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				401,
@@ -1455,6 +1967,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1475,6 +1995,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1495,6 +2023,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1515,6 +2051,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1535,6 +2079,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1555,6 +2107,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1575,6 +2135,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1595,6 +2163,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1616,6 +2192,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1637,6 +2221,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1658,6 +2250,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1679,6 +2279,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1701,6 +2309,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1725,6 +2341,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1748,6 +2372,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1770,6 +2402,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				401,

--- a/expConfigs/cory45_ILP.graph
+++ b/expConfigs/cory45_ILP.graph
@@ -2425,5 +2425,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_ILP_ac.graph
+++ b/expConfigs/cory45_ILP_ac.graph
@@ -2380,5 +2380,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_ILP_ac.graph
+++ b/expConfigs/cory45_ILP_ac.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -243,6 +251,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -258,6 +274,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -273,6 +297,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -288,6 +320,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -306,6 +346,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -324,6 +372,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -342,6 +398,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -359,6 +423,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -377,6 +449,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -395,6 +475,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403
@@ -411,6 +499,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -427,6 +523,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -443,6 +547,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -459,6 +571,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -475,6 +595,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -491,6 +619,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -508,6 +644,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -525,6 +669,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -543,6 +695,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -560,6 +720,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -576,6 +744,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -593,6 +769,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -610,6 +794,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -625,6 +817,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -640,6 +840,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -655,6 +863,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -670,6 +886,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -685,6 +909,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -700,6 +932,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -715,6 +955,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -730,6 +978,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -745,6 +1001,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -760,6 +1024,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503,
@@ -778,6 +1050,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -794,6 +1074,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -814,6 +1102,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -834,6 +1130,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -854,6 +1158,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -874,6 +1186,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -894,6 +1214,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -914,6 +1242,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -937,6 +1273,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -960,6 +1304,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503,
@@ -982,6 +1334,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1004,6 +1364,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -1027,6 +1395,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -1049,6 +1425,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1071,6 +1455,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -1092,6 +1484,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -1113,6 +1513,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403
@@ -1134,6 +1542,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -1155,6 +1571,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -1176,6 +1600,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403
@@ -1197,6 +1629,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1219,6 +1659,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1241,6 +1689,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1263,6 +1719,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1286,6 +1750,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -1309,6 +1781,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1331,6 +1811,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1352,6 +1840,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1374,6 +1870,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				502,
@@ -1396,6 +1900,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				503,
@@ -1418,6 +1930,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1438,6 +1958,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1458,6 +1986,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1478,6 +2014,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1498,6 +2042,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1518,6 +2070,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1538,6 +2098,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1558,6 +2126,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1578,6 +2154,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1598,6 +2182,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1618,6 +2210,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1638,6 +2238,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1658,6 +2266,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1681,6 +2297,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1703,6 +2327,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1725,6 +2357,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				401,

--- a/expConfigs/cory45_ILP_mt.graph
+++ b/expConfigs/cory45_ILP_mt.graph
@@ -2369,5 +2369,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_ILP_mt.graph
+++ b/expConfigs/cory45_ILP_mt.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -243,6 +251,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -258,6 +274,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -273,6 +297,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -288,6 +320,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -305,6 +345,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -322,6 +370,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -339,6 +395,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -356,6 +420,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -373,6 +445,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -390,6 +470,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -406,6 +494,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -422,6 +518,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -438,6 +542,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -454,6 +566,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -470,6 +590,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -486,6 +614,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -502,6 +638,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -519,6 +663,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -537,6 +689,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -553,6 +713,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -570,6 +738,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -587,6 +763,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -603,6 +787,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -618,6 +810,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -633,6 +833,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -648,6 +856,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -663,6 +879,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -678,6 +902,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -693,6 +925,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -709,6 +949,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -725,6 +973,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -741,6 +997,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -757,6 +1021,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -774,6 +1046,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -789,6 +1069,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -809,6 +1097,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -829,6 +1125,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -849,6 +1153,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -869,6 +1181,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -889,6 +1209,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -909,6 +1237,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -931,6 +1267,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -953,6 +1297,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -975,6 +1327,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -997,6 +1357,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -1019,6 +1387,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1041,6 +1417,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402
@@ -1062,6 +1446,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1083,6 +1475,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1104,6 +1504,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1125,6 +1533,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1146,6 +1562,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1167,6 +1591,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1188,6 +1620,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1209,6 +1649,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1231,6 +1679,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1253,6 +1709,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1275,6 +1739,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1297,6 +1769,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1318,6 +1798,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1340,6 +1828,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1362,6 +1858,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1384,6 +1888,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1405,6 +1917,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1425,6 +1945,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1445,6 +1973,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1465,6 +2001,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1485,6 +2029,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1505,6 +2057,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1525,6 +2085,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1545,6 +2113,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1566,6 +2142,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1587,6 +2171,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1608,6 +2200,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1629,6 +2229,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1650,6 +2258,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1672,6 +2288,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1694,6 +2318,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1716,6 +2348,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,

--- a/expConfigs/cory45_ILP_mt_ac.graph
+++ b/expConfigs/cory45_ILP_mt_ac.graph
@@ -2333,5 +2333,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_ILP_mt_ac.graph
+++ b/expConfigs/cory45_ILP_mt_ac.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -243,6 +251,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -258,6 +274,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -273,6 +297,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -288,6 +320,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -304,6 +344,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -320,6 +368,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -337,6 +393,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -354,6 +418,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -370,6 +442,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -386,6 +466,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -401,6 +489,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -416,6 +512,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -431,6 +535,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -446,6 +558,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -461,6 +581,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -476,6 +604,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -492,6 +628,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -508,6 +652,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -525,6 +677,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -541,6 +701,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -557,6 +725,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -573,6 +749,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -589,6 +773,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -604,6 +796,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -619,6 +819,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -634,6 +842,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -649,6 +865,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -664,6 +888,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -679,6 +911,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -694,6 +934,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -709,6 +957,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -724,6 +980,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -739,6 +1003,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -756,6 +1028,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -771,6 +1051,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -791,6 +1079,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -811,6 +1107,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -831,6 +1135,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -851,6 +1163,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -871,6 +1191,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -891,6 +1219,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -913,6 +1249,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -934,6 +1278,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -955,6 +1307,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -976,6 +1336,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -997,6 +1365,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -1018,6 +1394,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1040,6 +1424,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1060,6 +1452,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1080,6 +1480,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1100,6 +1508,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1120,6 +1536,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1140,6 +1564,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1160,6 +1592,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1181,6 +1621,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1202,6 +1650,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1223,6 +1679,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1245,6 +1709,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1267,6 +1739,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1288,6 +1768,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1309,6 +1797,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1330,6 +1826,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1351,6 +1855,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1372,6 +1884,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1392,6 +1912,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1412,6 +1940,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1432,6 +1968,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1452,6 +1996,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1472,6 +2024,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1492,6 +2052,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1512,6 +2080,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1532,6 +2108,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1552,6 +2136,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1572,6 +2164,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1592,6 +2192,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1612,6 +2220,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1634,6 +2250,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1656,6 +2280,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1679,6 +2311,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,

--- a/expConfigs/cory45_adaptability_aware.graph
+++ b/expConfigs/cory45_adaptability_aware.graph
@@ -2369,5 +2369,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_adaptability_aware.graph
+++ b/expConfigs/cory45_adaptability_aware.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -243,6 +251,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -258,6 +274,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -273,6 +297,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -288,6 +320,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -305,6 +345,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -322,6 +370,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -339,6 +395,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -356,6 +420,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -373,6 +445,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -390,6 +470,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -406,6 +494,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -422,6 +518,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -438,6 +542,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -454,6 +566,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -470,6 +590,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -486,6 +614,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -502,6 +638,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -519,6 +663,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -537,6 +689,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -553,6 +713,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -570,6 +738,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -587,6 +763,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -603,6 +787,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -618,6 +810,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -633,6 +833,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -648,6 +856,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -663,6 +879,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -678,6 +902,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -693,6 +925,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -709,6 +949,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -725,6 +973,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -741,6 +997,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -757,6 +1021,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -774,6 +1046,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -789,6 +1069,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -809,6 +1097,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -829,6 +1125,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -849,6 +1153,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -869,6 +1181,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -889,6 +1209,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -909,6 +1237,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -931,6 +1267,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -953,6 +1297,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -975,6 +1327,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -997,6 +1357,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -1019,6 +1387,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1041,6 +1417,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402
@@ -1062,6 +1446,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1083,6 +1475,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1104,6 +1504,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1125,6 +1533,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1146,6 +1562,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1167,6 +1591,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				403
@@ -1188,6 +1620,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1209,6 +1649,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1231,6 +1679,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1253,6 +1709,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1275,6 +1739,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1297,6 +1769,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1318,6 +1798,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1340,6 +1828,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1362,6 +1858,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				502,
@@ -1384,6 +1888,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1405,6 +1917,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1425,6 +1945,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1445,6 +1973,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1465,6 +2001,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1485,6 +2029,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1505,6 +2057,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1525,6 +2085,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1545,6 +2113,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1566,6 +2142,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1587,6 +2171,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1608,6 +2200,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1629,6 +2229,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				503
@@ -1650,6 +2258,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1672,6 +2288,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1694,6 +2318,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1716,6 +2348,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,

--- a/expConfigs/cory45_goal_aware.graph
+++ b/expConfigs/cory45_goal_aware.graph
@@ -2333,5 +2333,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_goal_aware.graph
+++ b/expConfigs/cory45_goal_aware.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -243,6 +251,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -258,6 +274,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -273,6 +297,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			]
@@ -288,6 +320,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -304,6 +344,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -320,6 +368,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				401,
@@ -337,6 +393,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -354,6 +418,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -370,6 +442,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -386,6 +466,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -401,6 +489,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -416,6 +512,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -431,6 +535,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -446,6 +558,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -461,6 +581,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			]
@@ -476,6 +604,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -492,6 +628,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -508,6 +652,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -525,6 +677,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -541,6 +701,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -557,6 +725,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -573,6 +749,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -589,6 +773,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -604,6 +796,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -619,6 +819,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -634,6 +842,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -649,6 +865,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -664,6 +888,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			]
@@ -679,6 +911,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -694,6 +934,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -709,6 +957,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -724,6 +980,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			]
@@ -739,6 +1003,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -756,6 +1028,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				502,
@@ -771,6 +1051,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -791,6 +1079,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -811,6 +1107,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -831,6 +1135,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -851,6 +1163,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -871,6 +1191,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401
 			],
@@ -891,6 +1219,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -913,6 +1249,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -934,6 +1278,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -955,6 +1307,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -976,6 +1336,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -997,6 +1365,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402
@@ -1018,6 +1394,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1040,6 +1424,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1060,6 +1452,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1080,6 +1480,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1100,6 +1508,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1120,6 +1536,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1140,6 +1564,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403
 			],
@@ -1160,6 +1592,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1181,6 +1621,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1202,6 +1650,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1223,6 +1679,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1245,6 +1709,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1267,6 +1739,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1288,6 +1768,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1309,6 +1797,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1330,6 +1826,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				501
@@ -1351,6 +1855,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501
@@ -1372,6 +1884,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1392,6 +1912,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1412,6 +1940,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1432,6 +1968,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1452,6 +1996,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1472,6 +2024,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1492,6 +2052,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502
 			],
@@ -1512,6 +2080,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1532,6 +2108,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1552,6 +2136,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1572,6 +2164,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1592,6 +2192,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503
 			],
@@ -1612,6 +2220,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				401,
@@ -1634,6 +2250,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				502,
@@ -1656,6 +2280,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1679,6 +2311,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,

--- a/expConfigs/cory45_less_naive.graph
+++ b/expConfigs/cory45_less_naive.graph
@@ -2511,5 +2511,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_less_naive.graph
+++ b/expConfigs/cory45_less_naive.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -247,6 +255,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				402,
@@ -266,6 +282,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -285,6 +309,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -304,6 +336,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -321,6 +361,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -338,6 +386,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -355,6 +411,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -372,6 +436,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -389,6 +461,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -406,6 +486,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -423,6 +511,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -440,6 +536,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -457,6 +561,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -474,6 +586,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -491,6 +611,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -508,6 +636,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				504,
@@ -526,6 +662,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				504,
@@ -544,6 +688,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -562,6 +714,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				504,
@@ -580,6 +740,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -598,6 +766,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -616,6 +792,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -634,6 +818,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -653,6 +845,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -672,6 +872,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -691,6 +899,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -710,6 +926,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -729,6 +953,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				501,
@@ -748,6 +980,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -765,6 +1005,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -782,6 +1030,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -799,6 +1055,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -816,6 +1080,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -834,6 +1106,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -850,6 +1130,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				504,
@@ -874,6 +1162,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				402,
@@ -898,6 +1194,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				403,
@@ -922,6 +1226,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -946,6 +1258,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -970,6 +1290,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -994,6 +1322,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1016,6 +1352,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1038,6 +1382,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1060,6 +1412,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1082,6 +1442,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1104,6 +1472,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1126,6 +1502,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				503,
@@ -1148,6 +1532,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1170,6 +1562,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1192,6 +1592,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1214,6 +1622,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1236,6 +1652,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1258,6 +1682,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1280,6 +1712,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				504,
@@ -1303,6 +1743,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				504,
@@ -1326,6 +1774,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				504,
@@ -1349,6 +1805,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1372,6 +1836,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1395,6 +1867,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -1418,6 +1898,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -1441,6 +1929,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -1464,6 +1960,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -1487,6 +1991,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				403,
@@ -1510,6 +2022,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1534,6 +2054,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1558,6 +2086,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1582,6 +2118,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1606,6 +2150,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1630,6 +2182,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1654,6 +2214,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				401,
@@ -1678,6 +2246,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1700,6 +2276,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1722,6 +2306,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1744,6 +2336,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1766,6 +2366,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1788,6 +2396,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1811,6 +2427,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1834,6 +2458,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1857,6 +2489,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,

--- a/expConfigs/cory45_situation_aware.graph
+++ b/expConfigs/cory45_situation_aware.graph
@@ -2762,5 +2762,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory45_situation_aware.graph
+++ b/expConfigs/cory45_situation_aware.graph
@@ -228,6 +228,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s401.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -249,6 +257,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s402.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				504,
@@ -270,6 +286,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s403.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -291,6 +315,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s404.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -312,6 +344,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s405.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -333,6 +373,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s406.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -354,6 +402,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s407.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -375,6 +431,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s408.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -396,6 +460,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s409.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -417,6 +489,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s410.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -438,6 +518,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s411.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				401,
@@ -459,6 +547,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s412.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -480,6 +576,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s413.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -501,6 +605,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s414.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -522,6 +634,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s415.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -543,6 +663,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s416.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -564,6 +692,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s501.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -585,6 +721,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s502.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -606,6 +750,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s503.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -627,6 +779,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s504.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -648,6 +808,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s505.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -669,6 +837,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s506.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -690,6 +866,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s507.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -711,6 +895,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s508.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -732,6 +924,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s509.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -753,6 +953,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s510.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -774,6 +982,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s511.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -795,6 +1011,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s512.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -816,6 +1040,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s513.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				403,
@@ -837,6 +1069,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s514.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -858,6 +1098,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s515.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -879,6 +1127,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s516.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -900,6 +1156,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s517.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -921,6 +1185,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s518.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -942,6 +1214,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s519.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -961,6 +1241,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c401.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -987,6 +1275,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c402.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				504,
@@ -1013,6 +1309,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c403.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				403,
@@ -1039,6 +1343,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c404.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -1065,6 +1377,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c405.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -1091,6 +1411,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c406.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				501,
 				402,
@@ -1117,6 +1445,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c407.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1143,6 +1479,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c408.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1169,6 +1513,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c409.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1195,6 +1547,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c410.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1221,6 +1581,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c411.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1247,6 +1615,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c412.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1273,6 +1649,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c413.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				502,
 				501,
@@ -1299,6 +1683,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c414.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -1325,6 +1717,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c415.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -1351,6 +1751,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c416.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				504,
 				503,
@@ -1377,6 +1785,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c417.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -1403,6 +1819,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c418.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				402,
@@ -1429,6 +1853,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c419.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				504,
@@ -1455,6 +1887,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c501.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1481,6 +1921,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c502.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1507,6 +1955,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c503.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1533,6 +1989,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c504.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1559,6 +2023,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c505.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				501,
@@ -1585,6 +2057,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c506.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1611,6 +2091,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c507.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1637,6 +2125,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c508.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				401,
 				402,
@@ -1663,6 +2159,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c509.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1689,6 +2193,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c510.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1715,6 +2227,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c511.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1741,6 +2261,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c512.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1767,6 +2295,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c513.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1793,6 +2329,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c514.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1819,6 +2363,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c515.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1845,6 +2397,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c516.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1871,6 +2431,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c517.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				501,
@@ -1897,6 +2465,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c518.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				402,
 				502,
@@ -1923,6 +2499,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c519.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -1949,6 +2533,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c520.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				402,
@@ -1975,6 +2567,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c521.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -2001,6 +2601,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c522.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				403,
 				504,
@@ -2027,6 +2635,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c523.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -2053,6 +2669,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c524.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -2079,6 +2703,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c525.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,
@@ -2105,6 +2737,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c526.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				503,
 				403,

--- a/expConfigs/cory5th.graph
+++ b/expConfigs/cory5th.graph
@@ -1374,5 +1374,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/cory5th.graph
+++ b/expConfigs/cory5th.graph
@@ -130,6 +130,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s01.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -147,6 +155,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s02.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -164,6 +180,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s03.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				2,
@@ -181,6 +205,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s04.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -198,6 +230,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s05.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				3,
@@ -215,6 +255,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s06.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				3,
@@ -232,6 +280,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s07.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				3,
@@ -249,6 +305,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s08.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -266,6 +330,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s09.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -283,6 +355,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s10.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -300,6 +380,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s11.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -317,6 +405,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s12.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -334,6 +430,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s13.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				1,
@@ -351,6 +455,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s14.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				1,
@@ -368,6 +480,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s15.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -385,6 +505,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s16.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				1,
@@ -402,6 +530,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s17.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				1,
@@ -419,6 +555,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s18.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				1,
@@ -436,6 +580,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s19.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				1,
@@ -451,6 +603,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c01.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -473,6 +633,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c02.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -495,6 +663,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c03.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -517,6 +693,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c04.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				2,
@@ -539,6 +723,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c05.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -561,6 +753,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c06.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -583,6 +783,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c07.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				3,
@@ -605,6 +813,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c08.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				3,
@@ -627,6 +843,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c09.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				3,
@@ -649,6 +873,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c10.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				3,
@@ -671,6 +903,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c11.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -693,6 +933,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c12.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -715,6 +963,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c13.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -737,6 +993,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c14.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -759,6 +1023,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c15.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -781,6 +1053,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c16.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -803,6 +1083,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c17.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				1,
 				3,
@@ -825,6 +1113,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c18.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				1,
@@ -847,6 +1143,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c19.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				1,
@@ -869,6 +1173,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c20.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -891,6 +1203,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c21.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				1,
@@ -913,6 +1233,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c22.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				1,
@@ -935,6 +1263,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c23.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				1,
@@ -957,6 +1293,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c24.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				1,
@@ -979,6 +1323,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c25.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				1,
@@ -1001,6 +1353,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c26.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				1,

--- a/expConfigs/cory5th_ILP.graph
+++ b/expConfigs/cory5th_ILP.graph
@@ -114,6 +114,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s01.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -131,6 +139,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s02.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -148,6 +164,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s03.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -164,6 +188,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s04.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -179,6 +211,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s05.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -194,6 +234,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s06.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				2,
@@ -211,6 +259,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s07.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -227,6 +283,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s08.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -242,6 +306,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s09.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -257,6 +329,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s10.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -272,6 +352,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s11.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -287,6 +375,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s12.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -302,6 +398,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s13.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			]
@@ -317,6 +421,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s14.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				4,
@@ -334,6 +446,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s15.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				2,
@@ -351,6 +471,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s16.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				4,
@@ -368,6 +496,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s17.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				4,
@@ -385,6 +521,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s18.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -401,6 +545,14 @@
 			"maxSessionKeysPerRequest": 1,
 			"netName": "Servers",
 			"credentialPrefix": "s19.Server",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -415,6 +567,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c01.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -437,6 +597,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c02.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2,
 				4,
@@ -459,6 +627,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c03.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -480,6 +656,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c04.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -501,6 +685,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c05.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -522,6 +714,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c06.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -542,6 +742,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c07.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -562,6 +770,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c08.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -582,6 +798,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c09.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				2,
@@ -604,6 +828,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c10.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -625,6 +857,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c11.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -645,6 +885,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c12.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -665,6 +913,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c13.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -685,6 +941,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c14.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -705,6 +969,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c15.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -725,6 +997,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c16.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -745,6 +1025,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c17.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				2
 			],
@@ -765,6 +1053,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c18.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				2,
@@ -787,6 +1083,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c19.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				4,
@@ -809,6 +1113,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c20.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				2,
@@ -831,6 +1143,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c21.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				4,
@@ -853,6 +1173,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c22.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				3,
 				4,
@@ -875,6 +1203,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c23.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -896,6 +1232,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c24.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -917,6 +1261,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c25.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2
@@ -938,6 +1290,14 @@
 			"maxSessionKeysPerRequest": 5,
 			"netName": "Clients",
 			"credentialPrefix": "c26.Client",
+			"distributionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
+			"sessionCryptoSpec": {
+				"cipher": "AES-128-CBC",
+				"mac": "SHA256"
+			},
 			"backupToAuthIds": [
 				4,
 				2

--- a/expConfigs/cory5th_ILP.graph
+++ b/expConfigs/cory5th_ILP.graph
@@ -1310,5 +1310,6 @@
 				}
 			]
 		}
-	]
+	],
+	"filesharingLists": []
 }

--- a/expConfigs/expGraphGenerator.js
+++ b/expConfigs/expGraphGenerator.js
@@ -138,6 +138,14 @@ function populateEchoServers() {
 			maxSessionKeysPerRequest: 1,
 			netName: 'Servers',
 			credentialPrefix: echoServer.name + '.Server',
+			distributionCryptoSpec: {
+                                cipher: "AES-128-CBC",
+                                mac: "SHA256"
+                        },
+                        sessionCryptoSpec: {
+                                cipher: "AES-128-CBC",
+                                mac: "SHA256"
+                        },
 			backupToAuthIds: echoServer.backupTo == null ? [] : echoServer.backupTo
 		}
 		serverHostPortMap[entity.name] = {host: entity.host, port: entity.port};
@@ -168,6 +176,14 @@ function populateAutoClients() {
 			maxSessionKeysPerRequest: 5,
 			netName: 'Clients',
 			credentialPrefix: autoClient.name + '.Client',
+			distributionCryptoSpec: {
+                                cipher: "AES-128-CBC",
+                                mac: "SHA256"
+                        },
+                        sessionCryptoSpec: {
+                                cipher: "AES-128-CBC",
+                                mac: "SHA256"
+                        },
 			backupToAuthIds: autoClient.backupTo == null ? [] : autoClient.backupTo
 		}
 		var targetServerInfoList = [];

--- a/expConfigs/expGraphGenerator.js
+++ b/expConfigs/expGraphGenerator.js
@@ -219,7 +219,8 @@ var graph = {
 	authList: authList,
 	authTrusts: authTrusts,
 	assignments: assignments,
-	entityList: entityList
+	entityList: entityList,
+	filesharingLists: []
 }
 
 fs.writeFileSync(outputGraphFileName, 

--- a/experiments/ccs2017/README.md
+++ b/experiments/ccs2017/README.md
@@ -57,6 +57,8 @@
   * This takes coordinates for entities (**$CCS/floorPlans/cory5th.txt**), predefined Auth-entity assignments (**$CCS/floorPlans/cory5thAssignments.json**), predefined Auth trusts (**$CCS/floorPlans/cory5thAuthTrusts.json**), and predefined Auth capacity (**$CCS/floorPlans/cory5thAuthCapacity.json**).
 
         cd $CCS
+        # Install required packages
+        ./initConfigs.sh 
         # for help
         node floorPlanToInput.js --help
         # for generating floor plan with predefined assignments and Auth trusts


### PR DESCRIPTION
Update experiments/ccs2017 README.md  - add ./initConfigs.sh under Experiment procedure to install required package.

Update graphs and expGraphGenerator.js to include distributionCryptoSpec, sessionCryptoSpec, and filesharingLists for compatibility with the current iotauth code.
