### PR TITLE
Update lxc.conf templete 

### DIFF
--- a/network_sim/linux_containers/templates/lxc.conf.template
+++ b/network_sim/linux_containers/templates/lxc.conf.template
@@ -6,4 +6,4 @@ NET_CONF
 lxc.mount.entry = HOST_MOUNT_DIR CONTAINER_MOUNT_POINT none bind,create=dir 0 0 
 lxc.mount.entry = /usr/bin usr/bin none bind,create=dir 0 0 
 lxc.mount.entry = /usr/lib usr/lib none bind,create=dir 0 0 
-lxc.mount.entry = /etc/alternatives etc/alternatives none bind,create=dir 0 0 
+lxc.mount.entry = /etc etc none bind,create=dir 0 0 


### PR DESCRIPTION
Extend lxc mount directory from /etc/alternatives to /etc to allow access to 'java.security' file required by the experiment.