### PR TITLE
Fix typos in experiments /ccs2017/README.md

### DIFF
--- a/experiments/ccs2017/README.md
+++ b/experiments/ccs2017/README.md
@@ -30,7 +30,7 @@
 
 **$TAP ($NS3/src/tap-bridge/examples)**
 
-* This directory includes SST simulation models using tap bridges. Currently used simulation models are *tap-matrix-sst.cc* and *tap-mixed-sst.cc*. Other files include *comm-cost.h* for CommCost class and *tap-csma-sst.cc* which was used for experimenting wired connections for Auths.
+* This directory includes SST simulation models using tap bridges. Currently used simulation models are *tap-matrix-sst.cc* and *tap-mixed-sst.cc*. Other files include *comm-cost.h* for the CommCost class and *tap-csma-sst.cc*, which was used for experimenting with wired connections for Auths.
 
 **$EXEC (iotauth_experiments/network_sim/container_execution)**
 
@@ -116,14 +116,14 @@
   ./generateAll.sh -g $CONF/ns3Exp.graph
   ```
 
-  * Run `make` if you have not built Auth jar before.
+  * Run `make` if you have not built the Auth jar before.
   
     ```
     cd $AUTH
     make
     ```
 
-* To set linux containers (LXCs). **generateAll.sh** will generate **tapConfigs.txt** that is used for ns3 simulation. The setup takes some time. See [LXC README.md](https://github.com/iotauth/iotauth_experiments/blob/master/network_sim/linux_containers/README.md) for more details. Do not forget to teardown LXCs with "./teardown-virtual-network.sh" before you create a new set of LXCs. (If not, it will cause problems because of the LXCs that are already there).
+* To set linux containers (LXCs). **generateAll.sh** will generate **tapConfigs.txt** that is used for ns3 simulation. The setup takes some time. See [LXC README.md](https://github.com/iotauth/iotauth_experiments/blob/master/network_sim/linux_containers/README.md) for more details. Do not forget to teardown LXCs with "./teardown-virtual-network.sh" before you create a new set of LXCs. (If not, it will cause problems because of the previous LXCs).
   ```
   cd $LXC
   # Clean up existing LXCs
@@ -142,6 +142,11 @@
 * To see current linux containers,
   ```
   sudo lxc-ls
+  ```
+  If you get this error `sudo: lxc-ls: command not found`, follow the steps below:
+  ```
+  sudo apt update
+  sudo apt install lxc lxc-utils
   ```
 
 * To setup ns3 network simulation environment (build is optional)
@@ -245,7 +250,7 @@
     node autoClient.js configs/Clients/t8.config 
     ```
 
-  * To simulate failure of an Auth
+  * To simulate the failure of an Auth
     ```
     sudo lxc-stop -n auth1
     ```

--- a/experiments/ccs2017/README.md
+++ b/experiments/ccs2017/README.md
@@ -1,4 +1,4 @@
-# Important directories and enviroment variables
+# Important directories and environment variables
 
 **$REPO_ROOT**
 
@@ -18,11 +18,11 @@
 
 **$AUTH ($IOT/auth/auth-server)**
 
-* This direcotry includes the neccsary files to execute the Auths. 
+* This directory includes the necessary files to execute the Auths. 
   
 **$LXC (iotauth_experiments/network_sim/linux_containers)**
 
-* This directory includes scripts for generating other scripts to set up, start, stop, and teardown linux containers (LXC, para-virtualmachines). The generation script uses *devList.txt* and *commCosts.txt* files. See [LXC README.md](https://github.com/iotauth/iotauth_experiments/blob/master/network_sim/linux_containers/README.md) for more details.
+* This directory includes scripts for generating other scripts to set up, start, stop, and teardown linux containers (LXC, para-virtual machines). The generation script uses *devList.txt* and *commCosts.txt* files. See [LXC README.md](https://github.com/iotauth/iotauth_experiments/blob/master/network_sim/linux_containers/README.md) for more details.
   
 **$NS3 (bake/source/ns-3.26)**
 
@@ -34,11 +34,11 @@
 
 **$EXEC (iotauth_experiments/network_sim/container_execution)**
 
-* This directory is for actually executing linux containers (LXCs) for Auths, servers, and clinets. As a result of LXC execution, the execution logs are stored in subdirectories *auth_execution* for Auth logs, *server_execution* for server logs, and *client_execution* for client logs.
+* This directory is for actually executing linux containers (LXCs) for Auths, servers, and clients. As a result of LXC execution, the execution logs are stored in subdirectories *auth_execution* for Auth logs, *server_execution* for server logs, and *client_execution* for client logs.
 
 **$CCS (iotauth_experiments/experiments/ccs2017)**
 
-* Current directory. This directory includes options for exepriments under $CCS/expOptions and contains scripts for copying logs and packet captures (pcap) to $CCS/results directory and scripts for analyzing the results, including availability and expected energy consumption.
+* Current directory. This directory includes options for experiments under $CCS/expOptions and contains scripts for copying logs and packet captures (pcap) to $CCS/results directory and scripts for analyzing the results, including availability and expected energy consumption.
 
 **$MOUNT_DIR**
 
@@ -187,7 +187,7 @@
     
 * To analyze results
   
-  * Copy results (logs and pcap files) to a directory that will be created under $CCS/results/YYMMDD-HHMMSS, (this also copies config files used for the experiments under $CCS/results/YYMMDD-HHMMSS/configs to use them in analysis such as the given communication costs, addresses of communication targets, and names devices and TAPs. **NOTE: Don't run this analysis as a super user (root)!!**
+  * Copy results (logs and pcap files) to a directory that will be created under $CCS/results/YYMMDD-HHMMSS, (this also copies config files used for the experiments under $CCS/results/YYMMDD-HHMMSS/configs to use them in analysis such as the given communication costs, addresses of communication targets, and names of devices and TAPs. **NOTE: Don't run this analysis as a super user (root)!!**
     ```
     exit
     cd $CCS
@@ -203,7 +203,7 @@
 
 * Details for running experiments
     
-  * To run Auths and servers background
+  * To run Auths and servers in the background
     ```
     sudo chroot /
     cd $EXEC


### PR DESCRIPTION
Fix typos and grammar.
Add the instruction for potential errors during the experiment.
